### PR TITLE
extend service type and CRITICAL state

### DIFF
--- a/check_monit.py
+++ b/check_monit.py
@@ -75,6 +75,11 @@ def service_output(service_type, element):
         inode = float(element.findall('inode/percent')[0].text)
         return 'user={0}%;inodes={1}%'.format(block, inode)
 
+    if service_type == 3:
+        # service type: PROCESS
+        status = element.find('status').text
+        return status
+    
     if service_type == 5:
         output = []
 
@@ -130,7 +135,7 @@ def main(args):
 
     for service in services:
         monitor = int(service.find('monitor').text)
-        if monitor == 1:
+        if monitor == 1 or monitor == 2:
             status = int(service.find('status').text)
             if status == 0:
                 count_ok += 1


### PR DESCRIPTION
https://github.com/NETWAYS/check_monit/issues/6

Returns the numerical status as text to icinga for service type 3 (PROCESS) of monit.

When in monit state _initializing_ do not ignore the monitor, but return the monitor as _CRITICAL_ to icinga.