### PR TITLE
service_type 7 && monitor all states !0

### DIFF
--- a/check_monit.py
+++ b/check_monit.py
@@ -109,7 +109,14 @@ def get_service_output(service_type, element):
 
     # Service Type Program
     if service_type == 7:
-        return element.findall('program/output')[0].text
+        return_value = None
+        for output_item in element.findall('program/output'):
+            # type( output_item ) is <class 'xml.etree.ElementTree.Element'>
+            return_value = output_item.text if return_value is None else f"{return_value}; {output_item.text}"
+        if return_value is None:
+            return_value = 'no command output available'
+
+        return return_value
 
     return 'Service (type={0}) not implemented'.format(service_type)
 
@@ -121,8 +128,8 @@ def get_service_states(services):
     for service in services:
         # Get the monitor state for the service (0: Not, 1: Yes, 2: Init, 4: Waiting)
         monitor = int(service.find('monitor').text)
-        # if the monitor is yes or initialize, check its status
-        if monitor in (1, 2):
+        # ignore 'Monitor_not' (0)
+        if monitor != 0:
             status = int(service.find('status').text)
             if status == 0:
                 count_ok += 1

--- a/test_check_monit.py
+++ b/test_check_monit.py
@@ -40,9 +40,17 @@ class CLITesting(unittest.TestCase):
         actual = get_service_output(3, input_element)
         self.assertEqual(actual, 'unittest')
 
+        input_element = ET.ElementTree(ET.fromstring("""<doc><program><output></output></program></doc>"""))
+        actual = get_service_output(7, input_element)
+        self.assertEqual(actual, 'no command output available')
+
         input_element = ET.ElementTree(ET.fromstring("""<doc><program><output>foobar</output></program></doc>"""))
         actual = get_service_output(7, input_element)
         self.assertEqual(actual, 'foobar')
+
+        input_element = ET.ElementTree(ET.fromstring("""<doc><program><output>foot</output><output>bath</output></program></doc>"""))
+        actual = get_service_output(7, input_element)
+        self.assertEqual(actual, 'foot; bath')
 
 class UtilTesting(unittest.TestCase):
 


### PR DESCRIPTION
Service type 7 (program) collects the output of the service in a list of xml elements. Check if this list is empty, concatenate all list values or set 'no command output available' as message for non existing output.

Instead of only taking in account monitor_states 1 (Yes) and 2 (Init) take all monitor_states in account that are not 0 (Not). There is no reason not to include information about any monitor that is not disabled.

unittests for service_type 7 program/output for empty element and for the unlikely case of more than one list elements.